### PR TITLE
Refactor docs and tooling for extensible PAL kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,44 @@
 # Proxy Attention Lab (PAL)
 
-**A laboratory for developing and benchmarking high-performance, custom paged attention kernels for MLX on Apple Silicon.**
+**A workbench for designing, iteratively testing, and benchmarking custom Metal kernels for the MLX framework.**
 
 ## Overview
 
-The Proxy Attention Lab (PAL) is a C++/Metal-based library designed to provide custom, high-performance MLX (https://github.com/ml-explore/mlx) operators, with an initial focus on paged attention mechanisms. Paged attention is a key technique used in modern Large Language Model (LLM) inference engines to efficiently manage and access the Key-Value (KV) cache, enabling larger batch sizes and longer sequence lengths.
+Proxy Attention Lab (PAL) provides a lightweight environment for experimenting with new GPU operators on Apple Silicon. While the initial kernel is a paged attention implementation, the project is structured to support any custom Metal kernel. PAL combines a C++/Metal core with Nanobind bindings so that each operator can be exercised from Python. Pytest drives unit and equivalency tests, with `pytest-benchmark` and Google Benchmark used for performance analysis. Results can be aggregated and visualised through the built in analysis scripts.
 
-This project aims to explore and implement production-quality paged attention kernels specifically optimized for Apple Silicon (M-series GPUs) using the Metal Shading Language, while integrating seamlessly with the MLX framework.
+## Philosophy
 
-## Prerequisites
+* **Modular design** – new kernels can be added without touching unrelated components.
+* **Rapid iteration** – Nanobind exposes the Metal primitives to Python, enabling test‑driven development.
+* **Comprehensive benchmarking** – Python and C++ benchmarks share a common results format that feeds into a report generator.
 
-*   macOS (for Metal development)
-*   Xcode Command Line Tools (includes Clang and Metal compilers)
-*   CMake (>= 3.20)
-*   Python (>= 3.11 recommended)
-*   `uv` (for Python package management, as used in `run.sh`) or `pip`
-*   MLX (PAL links against an existing MLX installation or can be adapted to fetch it)
-*   Nanobind
+## Directory Layout
 
-## Building and Testing
-
-The primary way to build PAL and run its tests is using the provided shell script:
-
-```bash
-./run.sh
+```
+src/
+  pal_core/              # C++ primitives, bindings and Metal sources
+  proxy_attention_lab/   # Python package exposing operations
+tests/                   # Unit tests and benchmarks
+scripts/                 # Helper scripts including benchmark runner and analyzer
 ```
 
-This script will:
-1.  Set up a Python virtual environment (if not already configured as per script).
-2.  Install/update Python dependencies using `uv pip install .`. This step also triggers the CMake build process for the C++ extension via `py-build-cmake`.
-3.  Run `pytest` on the `tests/` directory.
+## Usage
 
-To force a clean build:
+1. Ensure macOS with Xcode command line tools and Python 3.11+ are installed.
+2. Create a virtual environment and install PAL with its dependencies:
+
 ```bash
-CLEAN_BUILD=true ./run.sh
+python3 -m venv .venv
+source .venv/bin/activate
+uv pip install --no-deps git+https://github.com/TheProxyCompany/mlx.git nanobind==2.5.0
+uv pip install . --force-reinstall --no-build-isolation --no-cache-dir
 ```
 
-## Next Steps & Future Work (Tentative)
+3. Run tests:
 
-*   **Backward Pass Implementation:** Develop and test the backward pass for the paged attention kernel.
-*   **PIE Integration:** Fully integrate and validate PAL within the Proxy Inference Engine (PIE), ensuring correct data flow from PIE's scheduler and KV cache manager to PAL's paged attention operator.
+```bash
+pytest tests/
+```
+
+See `scripts/benchmarks.sh --help` for running and analysing benchmarks.
+

--- a/scripts/analyze_benchmarks.py
+++ b/scripts/analyze_benchmarks.py
@@ -1,11 +1,11 @@
-"""CLI tool for analyzing benchmark results."""
+"""CLI tool for analyzing PAL benchmark results for custom kernels."""
 
 from __future__ import annotations
 
 import argparse
 from pathlib import Path
 
-from benchmark_analyzer import config, loaders, plot_utils, reporters, transformers
+from benchmark_analyzer import loaders, plot_utils, reporters, transformers
 from benchmark_analyzer.plotters import (
     latency_vs_effective_items,
     latency_vs_head_dim,
@@ -33,9 +33,12 @@ def main() -> None:
     df = transformers.extract_and_normalize_parameters(raw_df)
     styles = plot_utils.get_plot_styles()
     plot_filenames: dict[str, str] = {}
-    plot_filenames["latency_vs_seq_len"] = latency_vs_seq_len.plot(df, args.output_dir, styles)
-    plot_filenames["latency_vs_head_dim"] = latency_vs_head_dim.plot(df, args.output_dir, styles)
-    plot_filenames["latency_vs_effective_items"] = latency_vs_effective_items.plot(df, args.output_dir, styles)
+    for k, v in latency_vs_seq_len.plot(df, args.output_dir, styles).items():
+        plot_filenames[f"latency_vs_seq_len_{k}"] = v
+    for k, v in latency_vs_head_dim.plot(df, args.output_dir, styles).items():
+        plot_filenames[f"latency_vs_head_dim_{k}"] = v
+    for k, v in latency_vs_effective_items.plot(df, args.output_dir, styles).items():
+        plot_filenames[f"latency_vs_effective_items_{k}"] = v
     model_plot = model_configs_latency.plot(df, args.output_dir, styles)
     if model_plot:
         plot_filenames["model_configs_latency"] = model_plot

--- a/scripts/benchmark_analyzer/__init__.py
+++ b/scripts/benchmark_analyzer/__init__.py
@@ -3,4 +3,4 @@
 from . import config, loaders, plot_utils, transformers
 from .reporters import generate_json_report
 
-__all__ = ["config", "loaders", "plot_utils", "transformers", "generate_json_report"]
+__all__ = ["config", "generate_json_report", "loaders", "plot_utils", "transformers"]

--- a/scripts/benchmark_analyzer/config.py
+++ b/scripts/benchmark_analyzer/config.py
@@ -12,6 +12,8 @@ DEFAULT_BATCH_SIZE = 64
 # Column names used across the package
 COL_BENCHMARK_NAME_BASE = "benchmark_name_base"
 COL_SOURCE = "source"
+COL_LANGUAGE = "language"
+COL_KERNEL_TESTED = "kernel_tested"
 COL_PARAMS_STR = "params_str"
 COL_MEAN_LATENCY = "mean_latency_ms"
 COL_THROUGHPUT = "throughput_items_per_sec"

--- a/scripts/benchmark_analyzer/plotters/__init__.py
+++ b/scripts/benchmark_analyzer/plotters/__init__.py
@@ -1,2 +1,1 @@
 """Plotter modules for benchmark analyzer."""
-

--- a/scripts/benchmark_analyzer/plotters/latency_vs_effective_items.py
+++ b/scripts/benchmark_analyzer/plotters/latency_vs_effective_items.py
@@ -8,28 +8,31 @@ import matplotlib.pyplot as plt
 import pandas as pd
 
 from .. import plot_utils
-from ..config import COL_MEAN_LATENCY, COL_SOURCE
+from ..config import COL_KERNEL_TESTED, COL_LANGUAGE, COL_MEAN_LATENCY
 
 STYLES = plot_utils.get_plot_styles()
 
 
-def plot(df: pd.DataFrame, output_dir: Path, styles: dict[str, str | float] | None = None) -> str:
-    """Generate latency vs effective items plot."""
+def plot(df: pd.DataFrame, output_dir: Path, styles: dict[str, str | float] | None = None) -> dict[str, str]:
+    """Generate latency vs effective items plots per kernel."""
     styles = styles or STYLES
-    fig, ax = plt.subplots(figsize=(8, 6))
-    for src, group in df.dropna(subset=["effective_items"]).groupby(COL_SOURCE):
-        ax.plot(group["effective_items"], group[COL_MEAN_LATENCY], label=src, marker="o")
-    plot_utils.apply_common_plot_aesthetics(
-        ax,
-        "Latency vs Effective Items",
-        "Effective Items",
-        "Mean Latency (ms)",
-        styles,
-        x_scale="log",
-        y_scale="log",
-    )
     output_dir.mkdir(parents=True, exist_ok=True)
-    filename = "latency_vs_effective_items.png"
-    fig.savefig(output_dir / filename, dpi=300)
-    plt.close(fig)
-    return filename
+    filenames: dict[str, str] = {}
+    for kernel, kdf in df.dropna(subset=["effective_items"]).groupby(COL_KERNEL_TESTED):
+        fig, ax = plt.subplots(figsize=(8, 6))
+        for lang, group in kdf.groupby(COL_LANGUAGE):
+            ax.plot(group["effective_items"], group[COL_MEAN_LATENCY], label=lang, marker="o")
+        plot_utils.apply_common_plot_aesthetics(
+            ax,
+            f"{kernel} Latency vs Effective Items",
+            "Effective Items",
+            "Mean Latency (ms)",
+            styles,
+            x_scale="log",
+            y_scale="log",
+        )
+        filename = f"latency_vs_effective_items_{kernel}.png"
+        fig.savefig(output_dir / filename, dpi=300)
+        plt.close(fig)
+        filenames[kernel] = filename
+    return filenames

--- a/scripts/benchmark_analyzer/plotters/latency_vs_head_dim.py
+++ b/scripts/benchmark_analyzer/plotters/latency_vs_head_dim.py
@@ -8,26 +8,29 @@ import matplotlib.pyplot as plt
 import pandas as pd
 
 from .. import plot_utils
-from ..config import COL_MEAN_LATENCY, COL_SOURCE
+from ..config import COL_KERNEL_TESTED, COL_LANGUAGE, COL_MEAN_LATENCY
 
 STYLES = plot_utils.get_plot_styles()
 
 
-def plot(df: pd.DataFrame, output_dir: Path, styles: dict[str, str | float] | None = None) -> str:
-    """Generate latency vs head dimension plot."""
+def plot(df: pd.DataFrame, output_dir: Path, styles: dict[str, str | float] | None = None) -> dict[str, str]:
+    """Generate latency vs head dimension plots per kernel."""
     styles = styles or STYLES
-    fig, ax = plt.subplots(figsize=(8, 6))
-    for src, group in df.dropna(subset=["head_dim"]).groupby(COL_SOURCE):
-        ax.plot(group["head_dim"], group[COL_MEAN_LATENCY], label=src, marker="o")
-    plot_utils.apply_common_plot_aesthetics(
-        ax,
-        "Latency vs Head Dimension",
-        "Head Dimension",
-        "Mean Latency (ms)",
-        styles,
-    )
     output_dir.mkdir(parents=True, exist_ok=True)
-    filename = "latency_vs_head_dim.png"
-    fig.savefig(output_dir / filename, dpi=300)
-    plt.close(fig)
-    return filename
+    filenames: dict[str, str] = {}
+    for kernel, kdf in df.dropna(subset=["head_dim"]).groupby(COL_KERNEL_TESTED):
+        fig, ax = plt.subplots(figsize=(8, 6))
+        for lang, group in kdf.groupby(COL_LANGUAGE):
+            ax.plot(group["head_dim"], group[COL_MEAN_LATENCY], label=lang, marker="o")
+        plot_utils.apply_common_plot_aesthetics(
+            ax,
+            f"{kernel} Latency vs Head Dimension",
+            "Head Dimension",
+            "Mean Latency (ms)",
+            styles,
+        )
+        filename = f"latency_vs_head_dim_{kernel}.png"
+        fig.savefig(output_dir / filename, dpi=300)
+        plt.close(fig)
+        filenames[kernel] = filename
+    return filenames

--- a/scripts/benchmark_analyzer/plotters/model_configs_latency.py
+++ b/scripts/benchmark_analyzer/plotters/model_configs_latency.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 
 from .. import plot_utils
-from ..config import COL_MEAN_LATENCY, COL_SOURCE
+from ..config import COL_KERNEL_TESTED, COL_MEAN_LATENCY, COL_SOURCE
 
 STYLES = plot_utils.get_plot_styles()
 
@@ -19,12 +19,13 @@ def plot(df: pd.DataFrame, output_dir: Path, styles: dict[str, str | float] | No
     cfg_df = df.dropna(subset=["model_config_name"])
     if cfg_df.empty:
         return ""
+    kernel = cfg_df[COL_KERNEL_TESTED].unique()[0] if not cfg_df.empty else "kernel"
     fig, ax = plt.subplots(figsize=(8, 6))
     pivot = cfg_df.pivot_table(index="model_config_name", columns=COL_SOURCE, values=COL_MEAN_LATENCY)
-    pivot.plot.bar(ax=ax, color=[styles["PAL_BAR_COLOR"], styles["SDPA_BAR_COLOR"]])
+    pivot.plot.bar(ax=ax, color=[styles.get("PAL_BAR_COLOR", "#333333"), styles.get("SDPA_BAR_COLOR", "#777777")])
     plot_utils.apply_common_plot_aesthetics(
         ax,
-        "Model Configuration Latency",
+        f"{kernel} Model Configuration Latency",
         "Model Config",
         "Mean Latency (ms)",
         styles,

--- a/scripts/benchmark_analyzer/reporters.py
+++ b/scripts/benchmark_analyzer/reporters.py
@@ -7,13 +7,13 @@ from pathlib import Path
 
 import pandas as pd
 
-from .config import COL_MEAN_LATENCY, COL_SOURCE
+from .config import COL_KERNEL_TESTED, COL_MEAN_LATENCY
 
 
 def generate_json_report(df: pd.DataFrame, output_dir: Path, plot_filenames: dict[str, str]) -> None:
-    """Generate a simple JSON report."""
+    """Generate a simple JSON report grouped by kernel."""
     report = {"summary_metrics": {}, "plot_files": plot_filenames}
-    if not df.empty:
-        report["summary_metrics"]["rows"] = len(df)
+    for kernel, kdf in df.groupby(COL_KERNEL_TESTED):
+        report["summary_metrics"][kernel] = {"mean_latency_ms": kdf[COL_MEAN_LATENCY].mean()}
     with open(output_dir / "results.json", "w") as f:
         json.dump(report, f, indent=2)

--- a/scripts/benchmark_analyzer/transformers.py
+++ b/scripts/benchmark_analyzer/transformers.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import re
-
 import pandas as pd
 
 from . import config
@@ -23,23 +21,29 @@ def extract_and_normalize_parameters(df: pd.DataFrame) -> pd.DataFrame:
     df["head_dim"] = pd.NA
     df["num_query_items"] = pd.NA
     df["batch_size"] = pd.NA
+    PARSER_MAP = {
+        "BM_PAL_LatencyVsSeqLen": lambda p: (
+            {"seq_len": _parse_int(p.split("/")[-1]), "num_query_items": config.DEFAULT_NUM_QUERY_ITEMS} if p else {}
+        ),
+        "test_pal_latency_vs_seq_len": lambda p: (
+            {"seq_len": _parse_int(p.split("/")[-1]), "num_query_items": config.DEFAULT_NUM_QUERY_ITEMS} if p else {}
+        ),
+        "BM_SDPA_LatencyVsNumItems": lambda p: {"batch_size": _parse_int(p.split("/")[0])} if p else {},
+        "test_sdpa_latency_vs_query_items": lambda p: {"batch_size": _parse_int(p.split("/")[0])} if p else {},
+        "BM_PAL_LatencyVsHeadDim": lambda p: {"head_dim": _parse_int(p.split("/")[-1])} if p else {},
+        "test_pal_latency_vs_head_dim": lambda p: {"head_dim": _parse_int(p.split("/")[-1])} if p else {},
+        "BM_SDPA_LatencyVsHeadDim": lambda p: {"head_dim": _parse_int(p.split("/")[-1])} if p else {},
+        "test_sdpa_latency_vs_head_dim": lambda p: {"head_dim": _parse_int(p.split("/")[-1])} if p else {},
+    }
+
     for idx, row in df.iterrows():
         base = row[config.COL_BENCHMARK_NAME_BASE]
         params = row[config.COL_PARAMS_STR]
-        source = row[config.COL_SOURCE]
-        if base in {"BM_PAL_LatencyVsSeqLen", "test_pal_latency_vs_seq_len"}:
-            if params:
-                df.at[idx, "seq_len"] = _parse_int(params.split("/")[-1])
-                df.at[idx, "num_query_items"] = config.DEFAULT_NUM_QUERY_ITEMS
-        elif base in {"BM_SDPA_LatencyVsNumItems", "test_sdpa_latency_vs_query_items"}:
-            if params:
-                df.at[idx, "batch_size"] = _parse_int(params.split("/")[0])
-        elif base in {"BM_PAL_LatencyVsHeadDim", "test_pal_latency_vs_head_dim"}:
-            if params:
-                df.at[idx, "head_dim"] = _parse_int(params.split("/")[-1])
-        elif base in {"BM_SDPA_LatencyVsHeadDim", "test_sdpa_latency_vs_head_dim"}:
-            if params:
-                df.at[idx, "head_dim"] = _parse_int(params.split("/")[-1])
+        parser = PARSER_MAP.get(base)
+        if parser:
+            updates = parser(params)
+            for key, value in updates.items():
+                df.at[idx, key] = value
     # Effective items for comparisons
     df["effective_items"] = df["num_query_items"].fillna(df["batch_size"])
     return df

--- a/src/pal_core/CMakeLists.txt
+++ b/src/pal_core/CMakeLists.txt
@@ -5,6 +5,8 @@ cmake_policy(SET CMP0135 NEW)
 set(PROJECT_NAME proxy_attention_lab)  # Top-level project name
 set(EXTENSION_NAME pal_core)           # Python module name
 set(CORE_LIB_NAME pal_core_lib)        # C++ Static Library name
+# pal_core can contain multiple primitives/kernels. New sources should be added
+# under src/ and kernels/ and listed here as the project grows.
 
 # --- C++ Settings ---
 set(CMAKE_CXX_STANDARD 23)

--- a/src/pal_core/README.md
+++ b/src/pal_core/README.md
@@ -1,0 +1,10 @@
+# pal_core
+
+The `pal_core` directory holds the C++ library that wraps Metal shaders and provides Nanobind bindings.
+
+- `include/pal_core/` – public C++ headers for primitives
+- `include/shaders/` – header files shared between C++ and Metal
+- `src/` – primitive implementations
+- `kernels/` – Metal shader source files
+- `bindings.cpp` – Nanobind module exposing primitives
+- `CMakeLists.txt` – builds `pal_core_lib` and the metal library so it can be imported from Python or linked from other C++ projects

--- a/src/proxy_attention_lab/README.md
+++ b/src/proxy_attention_lab/README.md
@@ -1,0 +1,5 @@
+# proxy_attention_lab Package
+
+This package exposes PAL operations to Python.
+
+Add Python wrappers for new Metal kernels in `ops.py` and re-export them in `__init__.py`.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,14 @@
+# Tests
+
+Each kernel in PAL has a dedicated subdirectory under `tests/`.
+
+```
+tests/
+  paged_attention/
+    unit_tests/        # functional tests
+    benchmarks/
+      python/         # pytest-benchmark scripts
+      cpp/            # Google Benchmark executables
+```
+
+When adding a new kernel, create a similar subdirectory and populate it with unit tests and benchmarks.


### PR DESCRIPTION
## Summary
- clarify project mission in README and add package READMEs
- overhaul benchmark runner for language+kernel targeting
- add language/kernel parsing in benchmark analyzer
- make plotters/report generator kernel aware
- document extensibility of pal_core in CMake file

## Testing
- `ruff check --fix scripts`
- `black scripts`
- `black scripts/analyze_benchmarks.py`
- ❌ `pytest -q` *(fails: pytest not installed)*