### PR TITLE
Implement benchmark parity for query vectors

### DIFF
--- a/benchmarks/analyzer/config.py
+++ b/benchmarks/analyzer/config.py
@@ -28,7 +28,7 @@ MODEL_CONFIG_PARAMETERS = {
         # PAL-specific parameters
         "tokens_per_page": 64,
         "num_sequences_in_batch": 1,
-        "pal_num_query_items": 64 * 64,  # 64 tokens in batch * 64 query heads
+        "pal_num_query_items": 4 * 1024 * 64,  # total query vectors budget
         # SDPA-specific parameters
         "sdpa_batch_size": 4,
     },
@@ -40,7 +40,7 @@ MODEL_CONFIG_PARAMETERS = {
         # PAL-specific parameters
         "tokens_per_page": 64,
         "num_sequences_in_batch": 1,
-        "pal_num_query_items": 64 * 32,  # 64 tokens in batch * 32 query heads
+        "pal_num_query_items": 4 * 1024 * 32,  # total query vectors budget
         # SDPA-specific parameters
         "sdpa_batch_size": 4,
     },
@@ -52,7 +52,7 @@ MODEL_CONFIG_PARAMETERS = {
         # PAL-specific parameters
         "tokens_per_page": 64,
         "num_sequences_in_batch": 1,
-        "pal_num_query_items": 64 * 128,  # 64 tokens in batch * 128 query heads
+        "pal_num_query_items": 4 * 1024 * 128,  # total query vectors budget
         # SDPA-specific parameters
         "sdpa_batch_size": 4,
     },

--- a/benchmarks/analyzer/plot_utils.py
+++ b/benchmarks/analyzer/plot_utils.py
@@ -17,8 +17,9 @@ def get_plot_styles() -> dict[str, str | float]:
     styles["PAL_PY_STYLE"] = "-"  # Solid
     styles["SDPA_CPP_STYLE"] = "-."  # Dash-dot
     styles["SDPA_PY_STYLE"] = ":"  # Dotted
-    styles["PAL_LINEWIDTH"] = 2.5
-    styles["SDPA_LINEWIDTH"] = 1.5
+    # Use consistent line widths for both kernels
+    styles["PAL_LINEWIDTH"] = 2.0
+    styles["SDPA_LINEWIDTH"] = 2.0
     styles["PAL_CPP_MARKER"] = "o"
     styles["PAL_PY_MARKER"] = "s"  # Square
     styles["SDPA_CPP_MARKER"] = "D"  # Diamond

--- a/benchmarks/paged_attention/cpp/test_paged_attention_cpp.cpp
+++ b/benchmarks/paged_attention/cpp/test_paged_attention_cpp.cpp
@@ -497,9 +497,9 @@ static void BM_SDPA_LatencyVsNumItems(benchmark::State& state) {
         out.eval();  // Ensure GPU computation completes
     }
 
-    // Set the number of items processed (batch_size * num_q_heads per iteration)
+    // Set the number of items processed (batch_size * num_q_heads * seq_len per iteration)
     // This matches the "num_query_items" metric in the PAL benchmarks
-    state.SetItemsProcessed(static_cast<long long>(batch_size * num_q_heads) * state.iterations());
+    state.SetItemsProcessed(static_cast<long long>(batch_size * num_q_heads * seq_len) * state.iterations());
 }
 
 // Register the SDPA benchmarks
@@ -551,9 +551,9 @@ static void BM_SDPA_ModelConfig(
         out.eval();
     }
 
-    // Set metrics for items processed (batch_size * num_q_heads)
+    // Set metrics for items processed (batch_size * num_q_heads * seq_len)
     // This matches the equivalent of "num_query_items" in PAL
-    state.SetItemsProcessed(static_cast<long long>(batch_size * num_q_heads) * state.iterations());
+    state.SetItemsProcessed(static_cast<long long>(batch_size * num_q_heads * seq_len) * state.iterations());
 }
 
 // Llama3 70B-like configuration


### PR DESCRIPTION
## Summary
- sync PAL/SDPA model configs on query‑vector counts
- use same linewidth for both kernels when plotting
- adjust decode batching benchmarks to fix context length
- count query vectors correctly in SDPA C++ benchmarks

## Testing
- `ruff format benchmarks/paged_attention/python/test_paged_attention_python.py benchmarks/analyzer/config.py benchmarks/analyzer/plot_utils.py`
- `ruff check benchmarks/paged_attention/python/test_paged_attention_python.py benchmarks/analyzer/config.py benchmarks/analyzer/plot_utils.py`
- `python -m pytest` *(fails: No module named pytest)*