### PR TITLE
Optimize paged attention kernel

### DIFF
--- a/src/pal_core/include/shaders/paged_attention_types.h
+++ b/src/pal_core/include/shaders/paged_attention_types.h
@@ -48,6 +48,7 @@ struct alignas(16) PagedAttentionParams {
   float    log_exp_min_clamp;             // Minimum value for exponent in exp function
   float    inv_sqrt_head_dim;             // 1/sqrt(head_dim) precomputed on host
   uint32_t pad_floats_per_row;            // Padding floats per row for K/V tiles
+  uint32_t tokens_per_page_shift;         // Precomputed log2(tokens_per_page) when power-of-two
 };
 
 // --- Assertions ---


### PR DESCRIPTION
## Summary
- prefetch page table slice into threadgroup memory
- use precomputed `tokens_per_page_shift`
- remove runtime shift calculation in Metal
- use 32‑bit math for offset calculation
- update host to compute shift and new memory layout

## Testing
- `pytest -k "nothing" -q` *(fails: ModuleNotFoundError: No module named 'mlx')*