### PR TITLE
Feat: Refactor Prefill Pass 2 Kernel for Cooperative Processing & Improved Resource Usage

### DIFF
--- a/benchmarks/paged_attention/cpp/test_paged_attention_cpp.cpp
+++ b/benchmarks/paged_attention/cpp/test_paged_attention_cpp.cpp
@@ -386,8 +386,8 @@ static void BM_MLX_SDPA_DecodeLatencyVsHistoryLen(benchmark::State& state) {
     }
 }
 
-const int REPETITIONS = 20; // magic number
-const int ITERATIONS = 10; // magic number
+const int REPETITIONS = 10; // magic number
+const int ITERATIONS = 20; // magic number
 
 BENCHMARK(BM_PAL_LatencyVsSeqLen)
    ->Arg(64)->Repetitions(REPETITIONS)->Iterations(ITERATIONS)

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -46,7 +46,7 @@ fi
 
 log "Installing/Updating PAL dependencies (including MLX, Nanobind from pyproject.toml)..."
 export CMAKE_BUILD_PARALLEL_LEVEL=8 # Set parallel build level to 8
-"$UV_EXECUTABLE_PATH" pip install --no-deps "git+https://github.com/TheProxyCompany/mlx.git" "nanobind==2.5.0"
+"$UV_EXECUTABLE_PATH" pip install --no-deps "git+https://github.com/TheProxyCompany/mlx.git" "nanobind==2.5.0" "py_build_cmake"
 
 "$UV_EXECUTABLE_PATH" pip install "." --force-reinstall --no-build-isolation --no-cache-dir
 

--- a/src/pal_core/include/pal_core/kernel_utils/kernel_constants.hpp
+++ b/src/pal_core/include/pal_core/kernel_utils/kernel_constants.hpp
@@ -19,7 +19,7 @@ namespace paged_attention {
     constexpr float kLogFp16DenormMinVal = -88.0f;
 
     // Prefill pass configuration
-    constexpr uint32_t PREFILL_PASS2_TOKEN_BLOCK_SIZE = 64;
+    constexpr uint32_t PREFILL_PASS2_TOKEN_BLOCK_SIZE = 16;
     constexpr uint32_t PREFILL_PASS2_QHEAD_BLOCK_SIZE = 8;
 
     // Memory and tiling constraints

--- a/src/pal_core/include/pal_core/paged_attention_primitive.hpp
+++ b/src/pal_core/include/pal_core/paged_attention_primitive.hpp
@@ -69,7 +69,8 @@ class PagedAttentionPrimitive : public mx::UnaryPrimitive {
     bool is_prefill = true
   );
 
-  static constexpr uint32_t SIMD_GROUPS_PER_GQA_GROUP_FACTOR = 4; // hand tuned; 4-6 seems to be the sweet spot
+  static constexpr uint32_t SIMD_GROUPS_PER_GQA_GROUP_FACTOR_PREFILL_PASS_1 = 6; // hand tuned; 4-6 seems to be the sweet spot
+  static constexpr uint32_t SIMD_GROUPS_PER_THREADGROUP_PASS2 = 8; // wip
 
   /**
    * @brief Evaluates the primitive on CPU.

--- a/tests/paged_attention/prefill/test_smoke.py
+++ b/tests/paged_attention/prefill/test_smoke.py
@@ -98,6 +98,14 @@ def test_paged_attention_smoke() -> None:
     logger.info(f"    Sequence lengths: {mock_sequence_lengths.shape}")
     logger.info(f"    Query token offsets: {mock_query_token_offset}")
 
+    mx.eval(mock_queries)
+    mx.eval(mock_k_cache_pool)
+    mx.eval(mock_v_cache_pool)
+    mx.eval(mock_page_table)
+    mx.eval(mock_sequence_lengths)
+    mx.eval(mock_query_to_seq_map)
+    mx.eval(mock_query_token_offset)
+
     try:
         # Run the paged attention operation
         out = paged_attention(


### PR DESCRIPTION
Cycle: TDD13

## Description

This pull request introduces a significant architectural refactor of the paged_attn_prefill_pass2_kernel and its corresponding C++ host setup in PagedAttentionPrimitive::_eval_gpu_prefill. The primary goal of this refactor was to address performance bottlenecks and resource inefficiencies in the previous Pass 2 implementation by shifting to a "Cooperative Block Processing" model.

## Previous State & Challenges (Prefill Pass 2)

- The previous Pass 2 kernel assigned a block of (QueryToken, QHead) items to each Threadgroup (TG). However, each thread within the TG processed its assigned items serially, with each thread performing a serial loop over all relevant history pages (params.num_active_batch_logical_pages).

- This resulted in underutilization of intra-threadgroup parallelism for the critical page-wise reduction/accumulation step.

- A major concern was the potentially excessive threadgroup memory (TGMem) usage due to per-thread O-accumulators, which could lead to low GPU occupancy and correctness issues (e.g., "only first item correct" bug if TGMem wasn't perfectly managed between items).

## Refactored Design - "Cooperative Block Processing"

### Threadgroup (TG) Responsibility

- A TG remains responsible for processing a block of params.pass2_token_block_size * params.pass2_qhead_block_size output items (defaulting to 16x8=128 items).
- Crucially, the TG now processes these items serially one by one.

### Intra-TG Cooperation (For Each Item)

For each individual item in its block, the entire TG (all its launched threads, e.g., 256) now cooperates to:

**Phase A (M_global Calculation)**: Cooperatively perform a multi-stage reduction over all relevant params.num_active_batch_logical_pages to find the global maximum attention score (M_item_shared_scalar) for the current item. This involves per-thread private maxes, SIMDgroup-level reduction to TGMem scratch (simdgroup_m_scratch), and a final TG-level reduction.

**Phase B (S_global & O_final Accumulation)**:
- SIMDgroups within the TG divide the params.num_active_batch_logical_pages.
- For each page, s_local_p and rescale_factor (derived from M_item_shared_scalar) are determined.
- Each SIMDgroup accumulates its s_sg_private_sum (simple sum, in registers).
- Lanes within each SIMDgroup cooperatively load o_partial_p for the page, scale by rescale_factor, and accumulate into the SIMDgroup's dedicated slice in simdgroup_o_partials[NumSIMDgroups][HeadDim] (TGMem).
- After all pages are processed by a SIMDgroup, its s_sg_private_sum is written to simdgroup_s_scratch.

**Phase C (Final TG-Level Reductions)**:
- One SIMDgroup sums simdgroup_s_scratch into *S_item_shared_scalar, applying Kahan summation at this final stage.
- All available TG threads cooperatively sum the simdgroup_o_partials vectors into the shared O_item_shared_accumulator[HeadDim].

**Phase D (Normalization & Write)**: The TG cooperatively normalizes O_item_shared_accumulator by *S_item_shared_scalar and writes the final half vector to global memory.

**TGMem Management**: Shared TGMem accumulators and scratch arrays are explicitly zeroed/initialized at the start of processing each new item by the TG, resolving potential stale data issues.

## C++ Primitive Changes (PagedAttentionPrimitive::_eval_gpu_prefill)

- The number of threads per TG for the Pass 2 kernel launch is now configured using a factor (PREFILL_PASS2_SIMD_GROUPS_PER_TG_FACTOR, e.g., 8) multiplied by actual_simd_width, then optimized by metal::MetalDispatcher::calculate_optimal_threads.
- The pass2_tg_mem_bytes calculation has been significantly revised to accurately reflect the much smaller memory footprint of the new cooperative design (approx. 4.75KB for HeadDim=128, 8 SIMDgroups), which is for processing one item at a time.
- Dispatch grid calculations for Pass 2 continue to use params.pass2_token_block_size and params.pass2_qhead_block_size.